### PR TITLE
Use the right version for windows

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -74,7 +74,7 @@ elseif ($runnerOs -eq "Windows") {
         $hostname = "$prefix-$instanceId"
         # echo will mess up the return value
         Write-Debug "Creating RavenDB container $hostname in $region (This can take a while.)"
-        $containerImage = "ravendb/ravendb:$($ravenDBVersion)-ubuntu-latest"
+        $containerImage = "ravendb/ravendb:$($ravenDBVersion)"
         $details = az container create --image $containerImage --name $hostname --location $region --dns-name-label $hostname --resource-group $resourceGroup --cpu 4 --memory 8 --ports 8080 38888 --ip-address public --environment-variables RAVEN_ARGS="--License.Eula.Accepted=true --Setup.Mode=None --Security.UnsecuredAccessAllowed=PublicNetwork --ServerUrl=http://0.0.0.0:8080 --PublicServerUrl=http://$($hostname).$($region).azurecontainer.io:8080 --ServerUrl.Tcp=tcp://0.0.0.0:38888 --PublicServerUrl.Tcp=tcp://$($hostname).$($region).azurecontainer.io:38888" | ConvertFrom-Json
 
         # echo will mess up the return value


### PR DESCRIPTION
Unfortunately, our validation checks are not yet good enough to capture errors within the setup step so the previous builds were green even though it could not pull the image :(

I guess we have to patch 1.3.0 and at some later stage improve the validation.

```text
ERROR: (InaccessibleImage) The image 'ravendb/ravendb:5.4-ubuntu-latest-ubuntu-latest' in container group 'psw-ravendb5671372820-single' is not accessible. Please check the image and registry credential.
Code: InaccessibleImage
Message: The image 'ravendb/ravendb:5.4-ubuntu-latest-ubuntu-latest' in container group 'psw-ravendb5671372820-single' is not accessible. Please check the image and registry credential.
ERROR: argument --resource-id: expected one argument
```

https://github.com/Particular/setup-ravendb-action/actions/runs/3573171522/jobs/6006918933