### PR TITLE
Validate RavenDB license

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -22,6 +22,7 @@ $RenewedRavenDBLicense = ($refreshResult.Content | ConvertFrom-Json).License | C
 
 # I want something to fail, and fail the workflow as well
 Invoke-WebRequest -Method POST -ContentType "application/json" -Body "{}" https://api.particular.net/hi
+if (!$?) { exit -1 }
 
 if ($runnerOs -eq "Linux") {
     Write-Output "Running RavenDB in container $($ContainerName) using Docker"

--- a/setup.ps1
+++ b/setup.ps1
@@ -164,7 +164,7 @@ if ($runnerOs -eq "Windows" -and (($RavenDBMode -eq "Cluster") -or ($RavenDBMode
 
     $leader = "$($ravenIpsAndPortsToVerify['Leader'].Ip):$($ravenIpsAndPortsToVerify['Leader'].Port)"
     # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
-    Invoke-WebRequest "http://$($leader)/admin/license/activate" -Method POST -Headers @{ 'Content-Type' = 'application/json'; 'charset' = 'UTF-8' } -Body "$($RenewedRavenDBLicense)"    if (!$?) {
+    Invoke-WebRequest "http://$($leader)/admin/license/activate" -Method POST -Headers @{ 'Content-Type' = 'application/json'; 'charset' = 'UTF-8' } -Body "$($RenewedRavenDBLicense)"
     if (!$?) {
         Write-Error "Unable to activate RavenDB license on cluster leader"
         exit -1

--- a/setup.ps1
+++ b/setup.ps1
@@ -184,7 +184,7 @@ if ($runnerOs -eq "Windows" -and (($RavenDBMode -eq "Cluster") -or ($RavenDBMode
 
     $leader = "$($ravenIpsAndPortsToVerify['Leader'].Ip):$($ravenIpsAndPortsToVerify['Leader'].Port)"
     # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
-    Invoke-WebRequest "http://$($leader)/admin/license/activate" -Method POST -Headers @{ 'Content-Type' = 'application/json'; 'charset' = 'UTF-8' } -Body "$($FormattedRavenDBLicenseLicense)"
+    Invoke-WebRequest "http://$($leader)/admin/license/activate" -Method POST -Headers @{ 'Content-Type' = 'application/json'; 'charset' = 'UTF-8' } -Body "$($FormattedRavenDBLicense)"
     if (!$?) {
         Write-Error "Unable to activate RavenDB license on cluster leader"
         exit -1

--- a/setup.ps1
+++ b/setup.ps1
@@ -151,7 +151,7 @@ function ValidateRavenLicense {
     )
     
     Write-Output "Checking license details on $name"
-    $licenseCheck = Invoke-WebRequest "http://$($leader)/license/status" -Method GET | ConvertFrom-Json
+    $licenseCheck = Invoke-WebRequest "http://$($hostAndPort)/license/status" -Method GET | ConvertFrom-Json
     if (!$?) {
         Write-Error "Unable to check license details on $name"
         exit -1

--- a/setup.ps1
+++ b/setup.ps1
@@ -140,8 +140,6 @@ Write-Output "::group::Testing connection"
 
 Write-Output "::endgroup::"
 
-
-
 # This is not entirely nice because the activitation for linux happens inside the compose infrastructure while for windows
 # we have to do it here. The cluster checks during the setup phase whether it can reach the nodes and that was easier to do within
 # the compose setup container. Maybe one day we will find a way to clean this up a bit.
@@ -179,7 +177,7 @@ if ($runnerOs -eq "Windows" -and (($RavenDBMode -eq "Single") -or ($RavenDBMode 
         exit -1
     }
 
-    ValidateRavenLicense "Single-Node Server" "$($ravenIpsAndPortsToVerify['Single'].Ip):$($ravenIpsAndPortsToVerify['Single'].Port"
+    ValidateRavenLicense "Single-Node Server" "$($ravenIpsAndPortsToVerify['Single'].Ip):$($ravenIpsAndPortsToVerify['Single'].Port)"
 }
 if ($runnerOs -eq "Windows" -and (($RavenDBMode -eq "Cluster") -or ($RavenDBMode -eq "Both"))) {
     Write-Output "Activating License on leader in the cluster"

--- a/setup.ps1
+++ b/setup.ps1
@@ -20,6 +20,9 @@ $refreshRequestBody = @{License = $RavenDBLicense | ConvertFrom-Json } | Convert
 $refreshResult = Invoke-WebRequest -Method POST -ContentType "application/json" -Body $refreshRequestBody https://api.ravendb.net/api/v2/license/lease
 $RenewedRavenDBLicense = ($refreshResult.Content | ConvertFrom-Json).License | ConvertTo-Json -Compress
 
+# I want something to fail, and fail the workflow as well
+Invoke-WebRequest -Method POST -ContentType "application/json" -Body "{}" https://api.particular.net/hi
+
 if ($runnerOs -eq "Linux") {
     Write-Output "Running RavenDB in container $($ContainerName) using Docker"
 


### PR DESCRIPTION
This PR:

* Validates the RavenDB license (at least on the Windows nodes of a test) using the `/license/status` endpoint
* Outputs how many days are left in the license
* Creates a warning (which will be visible in the Actions summary page) when the license has less than 60 days remaining.
* Fails fast (so that tests don't need to attempt to run) when any of the cluster setup or license activation steps fail