### PR TITLE
Bump to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,6 @@ inputs:
     description: When the action runs on a Windows agent, this tag is applied to the Azure container created by the action.
     required: true
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
   post: dist/index.js


### PR DESCRIPTION
Updating the Node version to 20, as Node 16 has been deprecated and is throwing errors.